### PR TITLE
Final package.json fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7353,11 +7353,19 @@
       }
     },
     "mem": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-      "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-6.1.0.tgz",
+      "integrity": "sha512-RlbnLQgRHk5lwqTtpEkBTQ2ll/CG/iB+J4Hy2Wh97PjgZgXgWJWrFF+XXujh3UUVLvR4OOTgZzcWMMwnehlEUg==",
       "requires": {
-        "mimic-fn": "^1.0.0"
+        "map-age-cleaner": "^0.1.3",
+        "mimic-fn": "^3.0.0"
+      },
+      "dependencies": {
+        "mimic-fn": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.0.0.tgz",
+          "integrity": "sha512-PiVO95TKvhiwgSwg1IdLYlCTdul38yZxZMIcnDSFIBUm4BNZha2qpQ4GpJ++15bHoKDtrW2D69lMfFwdFYtNZQ=="
+        }
       }
     },
     "merge-stream": {
@@ -8247,6 +8255,14 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+        },
+        "mem": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+          "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
         }
       }
     },
@@ -9276,11 +9292,6 @@
           }
         }
       }
-    },
-    "react-testing-library": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/react-testing-library/-/react-testing-library-8.0.1.tgz",
-      "integrity": "sha512-Gq4JC9r3prA4hYwo7afcbHHMFckO29+5Nrh2KblAEPuK/DWaU0bJE1vtpAgLhzhY9bBirmcgjjIHljHEwGAXKw=="
     },
     "react-timer-mixin": {
       "version": "0.13.4",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "firebase": "^7.14.0",
     "firestore": "^1.1.6",
     "haversine": "^1.1.1",
+    "mem": "^6.1.0",
     "react": "~16.9.0",
     "react-dom": "~16.9.0",
     "react-native": "https://github.com/expo/react-native/archive/sdk-36.0.0.tar.gz",
@@ -52,7 +53,6 @@
     "react-native-table-component": "^1.2.1",
     "react-native-web": "~0.11.7",
     "react-redux": "^7.2.0",
-    "react-testing-library": "^8.0.1",
     "redux": "^4.0.5",
     "redux-mock-store": "^1.5.4"
   },


### PR DESCRIPTION
Received a security warning from github, that the "mem" node_module needed to be updated, so I did that. Also I uninstalled "react_testing_library", because it was causing those red warnings to be thrown (we never actually used this library). Tested it out and everything still works the same.